### PR TITLE
Add backport to unbreak build on R-4.5

### DIFF
--- a/src/Rvector_utils.h
+++ b/src/Rvector_utils.h
@@ -2,6 +2,10 @@
 #define _RVECTOR_UTILS_H_
 
 #include <Rdefines.h>
+#include <Rversion.h>
+#if R_VERSION < R_Version(4, 6, 0)
+# define DATAPTR_RW(x) DATAPTR(x)
+#endif
 
 
 /* Note that R does not define NA_INTEGER, NA_REAL, or NA_STRING as const


### PR DESCRIPTION
@hpages I know this package is intended for bioc-devel/r-devel, but several components of R-universe run r-release to render things, so it would be nice if we can keep supporting that version too for now.

See https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports